### PR TITLE
Add support for comments in `OWNERS` files

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,16 @@ Multiple comma separated subscribers can be listed for the same filter.
 @data,@team-leads db
 ```
 
+Comments are supported by prefixing lines with `//`.
+
+```
+// this comment will be ignored
+//// this one two
+  // even this one with whitespace
+
+@data,@team-leads db
+```
+
 Find the owners for specific files by passing them to the `Owners.for` method.
 
 ```ruby

--- a/example/OWNERS
+++ b/example/OWNERS
@@ -1,2 +1,8 @@
+// comment
 @org/blog
 @multiple,@owners db
+//comment
+
+////// comment
+
+  // comment

--- a/lib/owners/config.rb
+++ b/lib/owners/config.rb
@@ -4,6 +4,8 @@ module Owners
   #
   # @api private
   class Config
+    COMMENT = /^\s*\/\//
+
     def initialize(file, contents = nil)
       @contents = contents || file.read
       @root = File.dirname(file.to_s)
@@ -40,7 +42,9 @@ module Owners
     end
 
     def subscriptions
-      @contents.split("\n").reject(&:empty?)
+      @contents.split("\n").reject do |subscription|
+        subscription.empty? || subscription =~ COMMENT
+      end
     end
   end
 end

--- a/spec/owners_cli_spec.rb
+++ b/spec/owners_cli_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe Owners::CLI do
   end
 
   describe "for_diff" do
-    let(:args) { ["for_diff", "0757297", "d0e67df"] }
+    let(:args) { ["for_diff", "781b3b2", "ba7cd78"] }
 
     context "without a specified file" do
       it "parses owners correctly" do

--- a/spec/owners_spec.rb
+++ b/spec/owners_spec.rb
@@ -82,8 +82,8 @@ RSpec.describe Owners do
     subject { described_class.for_diff(ref, base_ref) }
 
     context "when comparing one commit" do
-      let(:ref) { "0757297" }
-      let(:base_ref) { "6683118" }
+      let(:ref) { "781b3b2" }
+      let(:base_ref) { "6f4f89a" }
 
       it "parses owners correctly" do
         expect(subject).to eq(["@org/blog"])
@@ -91,8 +91,8 @@ RSpec.describe Owners do
     end
 
     context "when comparing multiple commits" do
-      let(:ref) { "0757297" }
-      let(:base_ref) { "d0e67df" }
+      let(:ref) { "781b3b2" }
+      let(:base_ref) { "ba7cd78" }
 
       it "parses owners correctly" do
         expect(subject).to eq(["@org/blog", "@whitespace", "data@example.com"])

--- a/spec/owners_spec.rb
+++ b/spec/owners_spec.rb
@@ -68,6 +68,14 @@ RSpec.describe Owners do
         expect(subject).to eq(["@multiple", "@org/blog", "@owners"])
       end
     end
+
+    context "with comments" do
+      let(:paths) { ["example/comment"] }
+
+      it "parses owners correctly" do
+        expect(subject).to eq(["@org/blog"])
+      end
+    end
   end
 
   describe ".for_diff" do


### PR DESCRIPTION
```
// comments are prefixed with two slashes
///// they can also have more than two slashes
   // the slashes can be prefixed with whitespace as well

@data db
```
