### PR TITLE
Refactor and add new features

### DIFF
--- a/example/OWNERS
+++ b/example/OWNERS
@@ -1,6 +1,6 @@
 // comment
 @org/blog
-@multiple,@owners db
+,,,@multiple,@owners,, db
 //comment
 
 ////// comment

--- a/lib/owners.rb
+++ b/lib/owners.rb
@@ -1,9 +1,11 @@
+require "delegate"
 require "pathname"
 require "set"
 require "thor"
 require_relative "owners/cli"
 require_relative "owners/config"
 require_relative "owners/search"
+require_relative "owners/subscription"
 require_relative "owners/tree"
 require_relative "owners/version"
 

--- a/lib/owners.rb
+++ b/lib/owners.rb
@@ -1,9 +1,9 @@
-require "delegate"
 require "pathname"
 require "set"
 require "thor"
 require_relative "owners/cli"
 require_relative "owners/config"
+require_relative "owners/owner"
 require_relative "owners/search"
 require_relative "owners/subscription"
 require_relative "owners/tree"
@@ -27,7 +27,7 @@ module Owners
     #
     # @api public
     def for(*files)
-      Search.new(files).owners
+      Search.new(files).results
     end
 
     # Accepts a git ref and an optional base ref and returns
@@ -49,7 +49,7 @@ module Owners
         hash.update(file => contents)
       end
 
-      Search.new(files, configs).owners
+      Search.new(files, configs).results
     end
   end
 end

--- a/lib/owners.rb
+++ b/lib/owners.rb
@@ -1,3 +1,4 @@
+require "delegate"
 require "pathname"
 require "set"
 require "thor"

--- a/lib/owners/cli.rb
+++ b/lib/owners/cli.rb
@@ -1,20 +1,45 @@
 module Owners
   class CLI < Thor
+    class_option :debug,
+      aliases: %w(-d),
+      desc: "Output additional subscription debugging info",
+      type: :boolean
+
+    class_option :file,
+      aliases: %w(-f),
+      desc: "The name of the OWNERS file",
+      type: :string
+
     desc "for [FILES...]", "List owners for a set of files"
-    method_option :file, desc: "The name of the OWNERS file"
     def for(*files)
       Owners.file = options[:file] if options[:file]
       Owners.for(*files).each do |owner|
-        puts owner
+        output(owner)
       end
     end
 
     desc "for_diff REF [BASE_REF]", "List owners for a set of git changes"
-    method_option :file, desc: "The name of the OWNERS file"
     def for_diff(ref, base_ref = "master")
       Owners.file = options[:file] if options[:file]
       Owners.for_diff(ref, base_ref).each do |owner|
-        puts owner
+        output(owner)
+      end
+    end
+
+    no_commands do
+      def output(owner)
+        say owner
+
+        if options[:debug]
+          owner.subscriptions.each do |path, subscriptions|
+            subscriptions.each do |sub|
+              say "  #{path}", :yellow
+              say "  #{sub.file}:#{sub.line} => #{sub.filter}", :blue
+            end
+
+            say
+          end
+        end
       end
     end
   end

--- a/lib/owners/config.rb
+++ b/lib/owners/config.rb
@@ -5,6 +5,7 @@ module Owners
   # @api private
   class Config
     COMMENT = /^\s*\/\//
+    WILDCARD = /.*/
 
     def initialize(file, contents = nil)
       @contents = contents || file.read
@@ -40,7 +41,7 @@ module Owners
 
     def subscribers(path, subscription)
       subscribers, filter = subscription.split(/\s+/, 2)
-      regex = Regexp.new(filter || ".*")
+      regex = Regexp.new(filter || WILDCARD)
 
       subscribers.split(",").tap do |owners|
         owners.clear unless path =~ regex

--- a/lib/owners/config.rb
+++ b/lib/owners/config.rb
@@ -39,8 +39,8 @@ module Owners
     end
 
     def subscribers(path, subscription)
-      subscribers, pattern = subscription.split(/\s+/, 2)
-      regex = Regexp.new(pattern || ".*")
+      subscribers, filter = subscription.split(/\s+/, 2)
+      regex = Regexp.new(filter || ".*")
 
       subscribers.split(",").tap do |owners|
         owners.clear unless regex =~ path

--- a/lib/owners/config.rb
+++ b/lib/owners/config.rb
@@ -1,6 +1,9 @@
 module Owners
-  # Parses an OWNERS file and returns an array of
-  # {Subscription} objects for a specified file path.
+  # Represents a single OWNERS file.
+  #
+  # It parses OWNERS files and returns an array of
+  # {Subscription} objects is returned for a specified
+  # file path.
   #
   # @api private
   class Config

--- a/lib/owners/config.rb
+++ b/lib/owners/config.rb
@@ -43,7 +43,7 @@ module Owners
       regex = Regexp.new(filter || ".*")
 
       subscribers.split(",").tap do |owners|
-        owners.clear unless regex =~ path
+        owners.clear unless path =~ regex
       end
     end
   end

--- a/lib/owners/config.rb
+++ b/lib/owners/config.rb
@@ -7,6 +7,12 @@ module Owners
     COMMENT = /^\s*\/\//
     WILDCARD = /.*/
 
+    def self.for(configs)
+      configs.map do |file, contents|
+        new(file, contents)
+      end
+    end
+
     def initialize(file, contents = nil)
       @contents = contents || file.read
       @root = File.dirname(file.to_s)

--- a/lib/owners/config.rb
+++ b/lib/owners/config.rb
@@ -50,6 +50,7 @@ module Owners
       regex = Regexp.new(filter || WILDCARD)
 
       subscribers.split(",").tap do |owners|
+        owners.reject!(&:empty?)
         owners.clear unless path =~ regex
       end
     end

--- a/lib/owners/owner.rb
+++ b/lib/owners/owner.rb
@@ -1,0 +1,32 @@
+module Owners
+  # Represents a unique "owner" across any number of OWNERS files.
+  #
+  # It is a simple wrapper around a {String} with some useful
+  # methods for inspecting an owner's type and subscriptions.
+  #
+  # @api public
+  class Owner < SimpleDelegator
+    def subscriptions
+      @subscriptions ||= Hash.new { |hash, key| hash[key] = [] }
+    end
+
+    def type
+      case to_s
+      when /^!/
+        :alert
+      when /^[\w+\-.]+@[a-z\d\-]+(\.[a-z]+)*\.[a-z]+$/i
+        :email
+      when /^@.+\/[^@]+$/
+        :group
+      when /^@/
+        :mention
+      when /^#/
+        :tag
+      when /\//
+        :path
+      else
+        :label
+      end
+    end
+  end
+end

--- a/lib/owners/search.rb
+++ b/lib/owners/search.rb
@@ -29,15 +29,11 @@ module Owners
     end
 
     def configs
-      if @configs
-        @configs.map { |file, contents| Config.new(file, contents) }
-      else
-        subscriptions.map { |file| Config.new(file) }
-      end
+      Config.for(@configs || subscriptions)
     end
 
     def subscriptions
-      trees.flat_map(&:owner_files).uniq
+      trees.flat_map(&:owner_files).uniq.product([nil])
     end
 
     def trees

--- a/lib/owners/search.rb
+++ b/lib/owners/search.rb
@@ -33,7 +33,7 @@ module Owners
     end
 
     def subscriptions
-      trees.flat_map(&:owner_files).uniq.product([nil])
+      trees.flat_map(&:owner_files).uniq
     end
 
     def trees

--- a/lib/owners/search.rb
+++ b/lib/owners/search.rb
@@ -4,6 +4,8 @@ module Owners
   #
   # @api private
   class Search
+    RELATIVE = /^\.?\//
+
     def initialize(files, configs = nil)
       @files = files.map(&:dup)
       @configs = configs
@@ -44,7 +46,7 @@ module Owners
 
     def paths
       @files.map do |file|
-        file.prepend("./") unless file =~ /^\.?\//
+        file.prepend("./") unless file =~ RELATIVE
         Pathname.new(file)
       end
     end

--- a/lib/owners/search.rb
+++ b/lib/owners/search.rb
@@ -13,8 +13,9 @@ module Owners
 
     def owners
       search do |(path, config), results|
-        owners = config.owners(path.to_s)
-        results.merge(owners) if owners
+        owners = config.subscriptions(path.to_s)
+        subscribers = owners.flat_map(&:subscribers)
+        results.merge(subscribers)
       end
     end
 

--- a/lib/owners/subscription.rb
+++ b/lib/owners/subscription.rb
@@ -1,0 +1,54 @@
+module Owners
+  # Represents a single line of an OWNERS file.
+  #
+  # @api public
+  class Subscription
+    extend Forwardable
+
+    COMMENT = /^\s*\/\//
+    WILDCARD = /.*/
+
+    attr_reader :line
+
+    def_delegators :@config, :file, :root
+
+    def initialize(subscription, line, config)
+      @subscribers, @filter = subscription.split(/\s+/, 2)
+      @subscription = subscription
+      @line = line
+      @config = config
+    end
+
+    def comment?
+      @subscription =~ COMMENT
+    end
+
+    def empty?
+      @subscription.strip.empty?
+    end
+
+    def filter
+      Regexp.new(@filter || WILDCARD)
+    end
+
+    def metadata?
+      comment? || empty?
+    end
+
+    def prefix
+      /\.?\/?#{root}\//
+    end
+
+    def relative(path)
+      path.sub(prefix, "")
+    end
+
+    def subscribed?(path)
+      path =~ prefix && relative(path) =~ filter
+    end
+
+    def subscribers
+      @subscribers.split(",").reject(&:empty?)
+    end
+  end
+end

--- a/lib/owners/subscription.rb
+++ b/lib/owners/subscription.rb
@@ -1,30 +1,31 @@
 module Owners
   # Represents a single line of an OWNERS file.
   #
+  # It contains some useful methods for inspecting the
+  # subscriptions themselves like the file, line, and
+  # filter, and subscribers.
+  #
   # @api public
   class Subscription
-    extend Forwardable
-
     COMMENT = /^\s*\/\//
     WILDCARD = /.*/
 
-    attr_reader :line
-
-    def_delegators :@config, :file, :root
+    attr_reader :file, :line, :root, :subscription
 
     def initialize(subscription, line, config)
       @subscribers, @filter = subscription.split(/\s+/, 2)
       @subscription = subscription
       @line = line
-      @config = config
+      @file = config.file
+      @root = config.root
     end
 
     def comment?
-      @subscription =~ COMMENT
+      subscription =~ COMMENT
     end
 
     def empty?
-      @subscription.strip.empty?
+      subscription.strip.empty?
     end
 
     def filter

--- a/spec/owner_spec.rb
+++ b/spec/owner_spec.rb
@@ -1,0 +1,61 @@
+RSpec.describe Owners::Owner do
+  describe "#type" do
+    subject { described_class.new(owner).type }
+
+    context "with an alert" do
+      let(:owner) { "!alert" }
+
+      it "parses type correctly" do
+        expect(subject).to eq(:alert)
+      end
+    end
+
+    context "with an email" do
+      let(:owner) { "test+extra@example.com" }
+
+      it "parses type correctly" do
+        expect(subject).to eq(:email)
+      end
+    end
+
+    context "with a group" do
+      let(:owner) { "@example/group-name" }
+
+      it "parses type correctly" do
+        expect(subject).to eq(:group)
+      end
+    end
+
+    context "with a mention" do
+      let(:owner) { "@test" }
+
+      it "parses type correctly" do
+        expect(subject).to eq(:mention)
+      end
+    end
+
+    context "with a tag" do
+      let(:owner) { "#test" }
+
+      it "parses type correctly" do
+        expect(subject).to eq(:tag)
+      end
+    end
+
+    context "with a path" do
+      let(:owner) { "/one/two" }
+
+      it "parses type correctly" do
+        expect(subject).to eq(:path)
+      end
+    end
+
+    context "with anything else" do
+      let(:owner) { "anything" }
+
+      it "parses type correctly" do
+        expect(subject).to eq(:label)
+      end
+    end
+  end
+end

--- a/spec/owners_cli_spec.rb
+++ b/spec/owners_cli_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe Owners::CLI do
     end
 
     context "with a specified file" do
-      before { args << "--file" << "SOMETHING_ELSE" }
+      before { args << "-f" << "SOMETHING_ELSE" }
 
       it "overrides the default OWNERS filename" do
         begin
@@ -32,6 +32,25 @@ RSpec.describe Owners::CLI do
         end
       end
     end
+
+    context "without debugging" do
+      before { args << "-d" }
+
+      it "parses owners correctly" do
+        expected = <<-OUTPUT
+@org/auth
+  ./example/app/controllers/users_controller.rb
+  ./example/app/OWNERS:1 => (?-mix:user)
+
+@org/blog
+  ./example/app/controllers/users_controller.rb
+  ./example/OWNERS:2 => (?-mix:.*)
+
+        OUTPUT
+
+        expect(subject).to eq(expected)
+      end
+    end
   end
 
   describe "for_diff" do
@@ -39,7 +58,7 @@ RSpec.describe Owners::CLI do
 
     context "without a specified file" do
       it "parses owners correctly" do
-        expect(subject).to eq("@org/blog\n@whitespace\ndata@example.com\n")
+        expect(subject).to eq("@org/blog\ndata@example.com\n@whitespace\n")
       end
     end
 

--- a/spec/owners_spec.rb
+++ b/spec/owners_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Owners do
       ]}
 
       it "parses owners correctly" do
-        expect(subject).to eq(["@org/auth", "@org/blog", "data@example.com"])
+        expect(subject).to eq(["@org/blog", "@org/auth", "data@example.com"])
       end
     end
 
@@ -41,7 +41,7 @@ RSpec.describe Owners do
       let(:paths) { ["example/app/models/blog.rb"] }
 
       it "parses owners correctly" do
-        expect(subject).to eq(["@blogger", "@org/blog", "data@example.com"])
+        expect(subject).to eq(["data@example.com", "@blogger", "@org/blog"])
       end
     end
 
@@ -49,7 +49,7 @@ RSpec.describe Owners do
       let(:paths) { ["example/app/models/post.rb"] }
 
       it "parses owners correctly" do
-        expect(subject).to eq(["@org/blog", "@whitespace", "data@example.com"])
+        expect(subject).to eq(["data@example.com", "@whitespace", "@org/blog"])
       end
     end
 
@@ -57,7 +57,7 @@ RSpec.describe Owners do
       let(:paths) { ["example/app/models/comment.rb"] }
 
       it "parses owners correctly" do
-        expect(subject).to eq(["@duplicate", "@org/blog", "@owner", "data@example.com"])
+        expect(subject).to eq(["data@example.com", "@owner", "@duplicate", "@org/blog"])
       end
     end
 
@@ -65,7 +65,7 @@ RSpec.describe Owners do
       let(:paths) { ["example/db/schema.rb"] }
 
       it "parses owners correctly" do
-        expect(subject).to eq(["@multiple", "@org/blog", "@owners"])
+        expect(subject).to eq(["@org/blog", "@multiple", "@owners"])
       end
     end
 
@@ -73,7 +73,7 @@ RSpec.describe Owners do
       let(:paths) { ["example/db/schema.rb"] }
 
       it "parses owners correctly" do
-        expect(subject).to eq(["@multiple", "@org/blog", "@owners"])
+        expect(subject).to eq(["@org/blog", "@multiple", "@owners"])
       end
     end
 
@@ -103,7 +103,7 @@ RSpec.describe Owners do
       let(:base_ref) { "ba7cd78" }
 
       it "parses owners correctly" do
-        expect(subject).to eq(["@org/blog", "@whitespace", "data@example.com"])
+        expect(subject).to eq(["@org/blog", "data@example.com", "@whitespace"])
       end
     end
   end

--- a/spec/owners_spec.rb
+++ b/spec/owners_spec.rb
@@ -69,6 +69,14 @@ RSpec.describe Owners do
       end
     end
 
+    context "with empty comma separated owners" do
+      let(:paths) { ["example/db/schema.rb"] }
+
+      it "parses owners correctly" do
+        expect(subject).to eq(["@multiple", "@org/blog", "@owners"])
+      end
+    end
+
     context "with comments" do
       let(:paths) { ["example/comment"] }
 


### PR DESCRIPTION
## Cleaned up and clarified code
- Extracted new constants
  - `Config::WILDCARD`
  - `Search::RELATIVE`
- Extracted new classes
  - `Owner`
  - `Subscription`
## Ignore empty comma separated owners

The example below now parses as `%w(trying @to #break this@example.com)`

```
,,trying,@to,,#break,,,this@example.com,,,,  db/migrate
```
## Return `Owner` objects instead of strings

``` ruby
Owners.for("app/models/user.rb", "db/schema.rb") #=> ["@data", "@team-leads"]
```

These new `Owner` objects are simple wrappers around `String` with additional useful methods.
##### `Owner#type`

Returns one of the following depending on the type of the owner:

``` ruby
def type
  case to_s
  when /^!/
    :alert
  when /^[\w+\-.]+@[a-z\d\-]+(\.[a-z]+)*\.[a-z]+$/i
    :email
  when /^@.+\/[^@]+$/
    :group
  when /^@/
    :mention
  when /^#/
    :tag
  when /\//
    :path
  else
    :label
  end
end
```
##### `Owner#subscriptions`

Returns an array of `Subscription` objects which represents a single line from an `OWNERS` file. These `Subscription` objects container useful methods for inspecting how and where a rule was matched like the `OWNERS` file path, line number, filter, and subscribers.

This extra information can also be displayed in the CLI by passing the `--debug` option:

![screenshot 2016-03-01 10 25 17](https://cloud.githubusercontent.com/assets/2419/13437217/edb44fdc-df97-11e5-9424-e291033e75dd.png)
## Sort `Owner` objects by closest match

The matches from the `OWNERS` files most closely nested to the files in question are returned first.
